### PR TITLE
Allow for included days to be set

### DIFF
--- a/cypress.env.example.json
+++ b/cypress.env.example.json
@@ -7,6 +7,7 @@
 	"partySize": 4,
 	"desiredTimeSlots": ["11:00 AM", "2:00 PM"],
 	"excludedDays": ["2023-03-16"],
+	"includedDays": [],
 	"slackWebhookUrl": "https://hooks.slack.com/services/{org_id}/{channel_id}/{hook_id}",
 	"slackUsername": "My Favorite Restaurant",
 	"slackIconEmoji": ":meat_on_bone:",

--- a/cypress/e2e/book-reservation.cy.ts
+++ b/cypress/e2e/book-reservation.cy.ts
@@ -5,6 +5,7 @@ interface Reservation {
 	partySize: number
 	desiredTimeSlots: string[]
 	excludedDays: string[]
+	includedDays: string[]
 	dryRun: boolean
 }
 
@@ -39,6 +40,7 @@ describe('book reservation', () => {
 			bookingPage: Cypress.env('bookingPage'),
 			desiredTimeSlots: Cypress.env('desiredTimeSlots'),
 			excludedDays: Cypress.env('excludedDays'),
+			includedDays: Cypress.env('includedDays'),
 			dryRun: Cypress.env('dryRun'),
 		}
 		cy.wrap(reservation.bookingPage).should('be.ok')
@@ -46,6 +48,7 @@ describe('book reservation', () => {
 		cy.wrap(reservation.dryRun).should('be.a', 'boolean')
 		cy.wrap(reservation.desiredTimeSlots).should('be.a', 'array')
 		cy.wrap(reservation.excludedDays).should('be.a', 'array')
+		cy.wrap(reservation.includedDays).should('be.a', 'array')
 
 	})
 
@@ -65,9 +68,12 @@ describe('book reservation', () => {
 			.get(tid('consumer-calendar-day'))
 			.filter('[aria-disabled=false].is-available')
 			.then((days) => cy.wrap(
-				days.filter((i, el) => 
-					reservation.excludedDays.length === 0 ||
-					reservation.excludedDays.indexOf(el.ariaLabel) < 0)
+				days.filter((i, el) => {
+					const dayLabel = el.ariaLabel
+					const isExcluded = reservation.excludedDays.length > 0 && reservation.excludedDays.indexOf(dayLabel) >= 0
+					const isIncluded = reservation.includedDays.length === 0 || reservation.includedDays.indexOf(dayLabel) >= 0
+					return !isExcluded && isIncluded
+				})
 			))
 	}
 


### PR DESCRIPTION
 Configuration files (cypress.env.json and cypress.env.example.json):
  - Added "includedDays": [] field

  Code changes (cypress/e2e/book-reservation.cy.ts):
  - Added includedDays: string[] to the Reservation interface
  - Added includedDays to the reservation configuration object
  - Added validation for the includedDays array
  - Updated the day filtering logic to support both excludedDays and includedDays

  Logic behavior:
  - If includedDays is empty (default), all days are considered (like before)
  - If includedDays has values, only those specific days are considered for booking
  - excludedDays still works as before and takes precedence over includedDays
  - A day must pass both filters: not be excluded AND be included (if includedDays is specified)

  The system now allows you to specify either approach:
  - excludedDays: ["2023-03-16"]` - book any day except March 16th
  - includedDays: ["2023-03-15", "2023-03-17"] - only book on March 15th or 17th
  - Both can be used together for fine-grained control

