### PR TITLE
fix: allow CVV to be a string for leading 0s to work

### DIFF
--- a/cypress.env.example.json
+++ b/cypress.env.example.json
@@ -1,7 +1,7 @@
 {
 	"email": "you@gmail.com",
 	"password": "tockpassword",
-	"cvv": 123,
+	"cvv": "123",
 	"trustee": false,
 	"bookingPage": "/{venue}/experience/{experience_id}/{experience_name}",
 	"partySize": 4,

--- a/cypress/e2e/book-reservation.cy.ts
+++ b/cypress/e2e/book-reservation.cy.ts
@@ -11,7 +11,7 @@ interface Reservation {
 interface Patron {
 	email: string
 	password: string
-	cvv: number
+	cvv: string
 }
 
 interface Booking {
@@ -32,7 +32,8 @@ describe('book reservation', () => {
 		}
 		cy.wrap(patron.email).should('be.ok')
 		cy.wrap(patron.password).should('be.ok')
-		cy.wrap(patron.cvv).should('be.a', 'number')
+		cy.wrap(patron.cvv).should('be.a', 'string')
+		cy.wrap(patron.cvv).should('match', /^[0-9]{3,4}$/)
 
 		reservation = {
 			partySize: Cypress.env('partySize'),
@@ -118,7 +119,7 @@ describe('book reservation', () => {
 				cy.get('iframe[type=cvv]')
 					.its('0.contentDocument.body')
 					.find('#cvv')
-					.type(patron.cvv.toString())
+					.type(patron.cvv)
 			} else {
 				cy.log(':money_with_wings: no deposit required...')	
 			}


### PR DESCRIPTION
Fixes #11 

Configuration files (cypress.env.json and cypress.env.example.json):
- Changed CVV type from number to string.

Code changes (cypress/e2e/book-reservation.cy.ts):
- Change cypress assert to CVV expecting a string
- Add cypress assert to match 3-4 number CVVs

Logic behavior:
- Previously Cypress expects CVV to be a number. This does not work when the CVV starts with 0:
- Now CVV must be enclosed in a string.
- Now CVV is validated against actual CVV standards of 0-9, 3-4 numbers.
- When adding the CVV in `fillFormFields`, we previously used toString. Now that can be removed since CVV is a string the whole time.

Validation:


<img width="401" height="127" alt="Screenshot 2025-08-25 at 4 56 45 PM" src="https://github.com/user-attachments/assets/03eb83f4-698a-4409-835b-88684a8350ed" />
<img width="386" height="135" alt="Screenshot 2025-08-25 at 4 52 49 PM" src="https://github.com/user-attachments/assets/a97de405-ea3f-4587-be40-9eb57f82c42c" />
